### PR TITLE
Disable go super linter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "gomod"
@@ -5,3 +6,9 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           go-version: 1.14
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Get build-release dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: Test
+name: Tests
 'on': [push]
 
 jobs:
@@ -9,8 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Super Linter
-        # This makes it pull from github's docker repo according to a note in the README.md
-        uses: docker://github/super-linter:v2.1.0
+        # This makes it pull from github's docker repo according to a note in
+        # the README.md
+        uses: docker://github/super-linter:v3
+        env:
+          # super-linter runs golangci-lint in a stupid way, just disable it
+          # and run it separately below
+          VALIDATE_GO: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   golangci-lint:
     name: golangci-lint on push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           go get -v -t -d ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be
           # specified without patch version: we always use the latest patch
           # version.
-          version: v1.27
+          version: v1.30


### PR DESCRIPTION
Stop super-linter from running golangci-lint
Editorial changes
Upgrade golangci-lint action to newer version
Enable dependabot to update github actions versions